### PR TITLE
Fix creation of SHA512 Crypto service

### DIFF
--- a/LicencingNET/Licence.cs
+++ b/LicencingNET/Licence.cs
@@ -158,7 +158,7 @@ namespace LicencingNET
                 return ValidationResult.NotStarted;
             }
 
-            using (SHA512CryptoServiceProvider sha = new SHA512CryptoServiceProvider())
+            using (SHA512 sha = SHA512.Create())
             {
                 byte[] licenceBinary = ToBinary(false);
 
@@ -209,7 +209,7 @@ namespace LicencingNET
                 throw new ArgumentNullException(nameof(privateKey), "Private key cannot be null");
             }
 
-            using (SHA512CryptoServiceProvider sha = new SHA512CryptoServiceProvider())
+            using (SHA512 sha = SHA512.Create())
             {
                 byte[] licenceBinary = ToBinary(false);
 

--- a/LicencingNET/LicencingNET.csproj
+++ b/LicencingNET/LicencingNET.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>7.1</LangVersion>
-    <TargetFrameworks>net35;net45;net471;netcoreapp2.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net45;net471;netcoreapp3.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I'm using this library in my project and it thows an error if the SHA512CryptoService is created using the constructor

```csharp
using (SHA512CryptoService sha = new SHA512CryptoService())
{
    byte[] licenceBinary = ToBinary(false);
    
    if (privateKey is RSACryptoServiceProvider rsa && !rsa.PublicOnly)
    {
        // The following line throws an ArgumentException saying the sha argument is not a valid crypto provider
        byte[] signature = rsa.SignData(licenceBinary, sha);
        Signature = signature;
        return true;
    }
}                
```

In NET Framework 3.5, the class `SHA512CryptoService` throws
an error when instantiated in the regular way. If I replace the
`new SHA512CryptoService()` with a `SHA512.Create()`, it works fine. I don't know for other NET versions, since I'm currently working with that. 

Also, all the official microsoft documentation examples are using `SHA512.Create()`. I don't know a lot about cryptography so I don't really know if this change is a breaking change (I don't think so).

This PR fixes this issue. If you can review it it would be awesome. 